### PR TITLE
Fix and add missing generic type hints

### DIFF
--- a/src/Type/ExplicitType.php
+++ b/src/Type/ExplicitType.php
@@ -34,10 +34,12 @@ class ExplicitType extends Type
 
     /**
      * Get the underlying builtin type.
+     *
+     * @return BuiltinType<T>
      */
     public function getBuiltinType(): BuiltinType
     {
-        return Type::builtin($this->typeIdentifier);
+        return new BuiltinType($this->typeIdentifier);
     }
 
     public function getExplicitType(): string

--- a/src/TypeFactoryTrait.php
+++ b/src/TypeFactoryTrait.php
@@ -13,7 +13,14 @@ trait TypeFactoryTrait
 {
     use BaseTypeFactoryTrait;
 
-    public static function explicit(TypeIdentifier|string $identifier, string $explicitType): ExplicitType
+    /**
+     * @template T of TypeIdentifier
+     *
+     * @param T $identifier
+     *
+     * @return ExplicitType<T>
+     */
+    public static function explicit(TypeIdentifier $identifier, string $explicitType): ExplicitType
     {
         return new ExplicitType($identifier, $explicitType);
     }

--- a/src/TypeResolver/ResolverExtrasTrait.php
+++ b/src/TypeResolver/ResolverExtrasTrait.php
@@ -40,7 +40,7 @@ trait ResolverExtrasTrait
     }
 
     /**
-     * @param array<BaseType> $variableTypes
+     * @param list<BaseType> $variableTypes
      */
     protected function tryAsClassLike(BaseType $type, array $variableTypes): ?ClassLikeType
     {
@@ -53,7 +53,7 @@ trait ResolverExtrasTrait
         return null;
     }
 
-    public function reduceToBuiltinType(?BaseType $type)
+    public function reduceToBuiltinType(?BaseType $type): ?BaseType
     {
         return $type instanceof ExplicitType
             ? $type->getBuiltinType()

--- a/tests/Type/ExplicitTypeTest.php
+++ b/tests/Type/ExplicitTypeTest.php
@@ -8,12 +8,12 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
 
 class ExplicitTypeTest extends TestCase
 {
-    public function testToString()
+    public function testToString(): void
     {
         $this->assertSame('numeric-int', (string) new ExplicitType(TypeIdentifier::INT, 'numeric-int'));
     }
 
-    public function testIsIdentifiedBy()
+    public function testIsIdentifiedBy(): void
     {
         $this->assertFalse((new ExplicitType(TypeIdentifier::INT, 'numeric-int'))->isIdentifiedBy(TypeIdentifier::ARRAY));
         $this->assertTrue((new ExplicitType(TypeIdentifier::INT, 'numeric-int'))->isIdentifiedBy(TypeIdentifier::INT));
@@ -23,7 +23,7 @@ class ExplicitTypeTest extends TestCase
         $this->assertTrue((new ExplicitType(TypeIdentifier::INT, 'numeric-int'))->isIdentifiedBy('string', 'int'));
     }
 
-    public function testIsNullable()
+    public function testIsNullable(): void
     {
         $this->assertFalse((new ExplicitType(TypeIdentifier::INT, 'numeric-int'))->isNullable());
     }

--- a/tests/Type/IntRangeTypeTest.php
+++ b/tests/Type/IntRangeTypeTest.php
@@ -9,7 +9,7 @@ use Radebatz\TypeInfoExtras\Type\Type;
 
 class IntRangeTypeTest extends TestCase
 {
-    public function testToString()
+    public function testToString(): void
     {
         $this->assertSame('int<0, max>', (string) new IntRangeType(from: 0, explicitType: 'int<0, max>'));
         $this->assertSame('int<min, 0>', (string) new IntRangeType(to: 0, explicitType: 'int<min, 0>'));
@@ -21,7 +21,7 @@ class IntRangeTypeTest extends TestCase
         $this->assertSame('int<min, 5>', (string) new IntRangeType(to: 5, explicitType: 'int<min, 5>'));
     }
 
-    public function testAccepts()
+    public function testAccepts(): void
     {
         $this->assertFalse((new IntRangeType(from: 0, to: 5, explicitType: 'int<0, 5>'))->accepts('string'));
         $this->assertFalse((new IntRangeType(from: 0, to: 5, explicitType: 'int<0, 5>'))->accepts([]));

--- a/tests/TypeResolver/StringTypeResolverTest.php
+++ b/tests/TypeResolver/StringTypeResolverTest.php
@@ -31,6 +31,9 @@ class StringTypeResolverTest extends BaseTypeResolverTest
         $this->resolver = new StringTypeResolver();
     }
 
+    /**
+     * @return iterable<array{BaseType, string, 2?: TypeContext|null}>
+     */
     public static function extrasResolveDataProvider(): iterable
     {
         foreach (parent::resolveDataProvider() as $key => $set) {
@@ -71,13 +74,13 @@ class StringTypeResolverTest extends BaseTypeResolverTest
     }
 
     #[DataProvider('extrasResolveDataProvider')]
-    public function testResolve(BaseType $expectedType, string $string, ?TypeContext $typeContext = null)
+    public function testResolve(BaseType $expectedType, string $string, ?TypeContext $typeContext = null): void
     {
         $this->assertEquals($expectedType, $this->resolver->resolve($string, $typeContext));
     }
 
     #[DataProvider('extrasResolveDataProvider')]
-    public function testResolveStringable(BaseType $expectedType, string $string, ?TypeContext $typeContext = null)
+    public function testResolveStringable(BaseType $expectedType, string $string, ?TypeContext $typeContext = null): void
     {
         $this->assertEquals($expectedType, $this->resolver->resolve(new class ($string) implements \Stringable {
             public function __construct(private string $value)


### PR DESCRIPTION
## Summary
- Add `@template`/`@param`/`@return` annotations to `ExplicitType::getBuiltinType()` and `TypeFactoryTrait::explicit()` for proper generic propagation
- Narrow `explicit()` parameter from `TypeIdentifier|string` to `TypeIdentifier` (all callers already pass enum values)
- Add missing return type `?BaseType` to `ResolverExtrasTrait::reduceToBuiltinType()`
- Use `list<BaseType>` instead of `array<BaseType>` for ordered collections
- Add `void` return types and iterable PHPDoc to test methods

## Test plan
- [x] All 271 PHPUnit tests pass
- [x] PHPStan at configured level 5 reports no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)